### PR TITLE
Changeci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - env: TEST=single_sample
     - env: TEST=two_sample
     # Below is for testing if all files are valid and if all submodules are up to date.
-    - env: TEST=Womtool validate and submodule up to date
+    - env: TEST="Womtool validate and submodule up to date"
       stage: lint
       install:
         - conda install cromwell

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ matrix:
   include:
     - env: TEST=single_sample
     - env: TEST=two_sample
-    # Below is for testing if all files are valid and if all submodules are up to date.
     - env: TEST="Womtool validate and submodule up to date"
       stage: lint
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ before_install:
   - conda config --add channels bioconda
   - conda config --add channels conda-forge
 
+stages:
+  - lint
+  - test
+
+stage: test
+
 install:
   - conda install --file requirements-test.txt
 
@@ -31,19 +37,7 @@ matrix:
     - env: TEST=two_sample
     # Below is for testing if all files are valid and if all submodules are up to date.
     - env: TEST=Womtool validate and submodule up to date
+      stage: lint
       install:
         - conda install cromwell
-      script:
-        - set -e
-        - for F in *.wdl; do echo $F; womtool validate $F; done
-        - >
-          if [ "$TRAVIS_PULL_REQUEST" != "false" ];
-          then git submodule foreach --recursive bash -c
-          'if [ "$(git tag --contains)" == "" ] ;
-          then git checkout develop && git pull &&
-          git submodule update --init --recursive ;
-          else echo "on tag: $(git tag --contains)" ; fi' ;
-          fi
-        - >
-          git diff --exit-code ||
-          (echo ERROR: Git changes detected. Submodules should either be tagged or on the latest version of develop. && exit 1)
+      script: bash scripts/biowdl_lint.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
         string name: 'THREADS', defaultValue: '${DEFAULT}'
         string name: 'OUTPUT_DIR', defaultValue: '${DEFAULT}'
         string name: 'TAGS', defaultValue: '${DEFAULT}'
+        string name: 'LINT', defaultValue: '${DEFAULT}'
     }
     stages {
         stage('Init') {
@@ -37,6 +38,7 @@ pipeline {
         }
 
         stage('lint') {
+            when { environment name: 'LINT', value: 'true' }
             steps {
                 sh 'bash scripts/biowdl_lint.sh'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,12 @@ pipeline {
             }
         }
 
+        stage('lint') {
+            steps {
+                sh 'bash scripts/biowdl_lint.sh'
+            }
+        }
+
         stage('Submodules develop') {
             when {
                 branch 'develop'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,8 +41,7 @@ pipeline {
         stage('lint') {
             when { environment name: 'LINT', value: 'true' }
             steps {
-                sh 'bash -c "export PATH=$PATH:$CROMWELL_PATH"'
-                sh 'bash scripts/biowdl_lint.sh'
+                sh 'bash -c "PATH=$PATH:$CROMWELL_PATH bash scripts/biowdl_lint.sh"'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
         string name: 'OUTPUT_DIR', defaultValue: '${DEFAULT}'
         string name: 'TAGS', defaultValue: '${DEFAULT}'
         string name: 'LINT', defaultValue: '${DEFAULT}'
+        string name: 'CROMWELL_PATH', defaultValue: '${DEFAULT}'
     }
     stages {
         stage('Init') {
@@ -40,6 +41,7 @@ pipeline {
         stage('lint') {
             when { environment name: 'LINT', value: 'true' }
             steps {
+                sh 'bash -c "export PATH=$PATH:$CROMWELL_PATH"'
                 sh 'bash scripts/biowdl_lint.sh'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ pipeline {
     }
     parameters {
         string name: 'PYTHON', defaultValue: '${DEFAULT}'
-        string name: 'CROMWELL_BIN', defaultValue: '${DEFAULT}'
         string name: 'THREADS', defaultValue: '${DEFAULT}'
         string name: 'OUTPUT_DIR', defaultValue: '${DEFAULT}'
         string name: 'TAGS', defaultValue: '${DEFAULT}'
@@ -59,7 +58,7 @@ pipeline {
             steps {
                 sh "#!/bin/bash\n" +
                         "set -e -v  -o pipefail\n" +
-                        "export PATH=$PATH:$CROMWELL_BIN\n" +
+                        "export PATH=$PATH:$CROMWELL_PATH\n" +
                         "${PYTHON} -m pytest -v --keep-workflow-wd --workflow-threads ${THREADS} --basetemp ${outputDir} ${TAGS} tests/"
             }
         }


### PR DESCRIPTION
This adds a linting stage to both .travis.yml and the jenkins file. Using the script in the scripts submodule.

Advantages:
1. The linting script is in a central place and is the same for all pipelines.
2. Failing the linting stage, no expensive long-running pipeline tests will performed. This will dramatically reduce the load on our cluster and on travis. 
3. Because the linting stage is always run first, typo's, out-of-data/unstable submodules are detected very early in the process. This makes releasing and development faster.
