### PR TITLE
remove pedigree for population founders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ that users understand how the changes affect the new version.
 -->
 version 2.0.0-dev
 -----------------
-+ Add input for a pedigree file, so the pipeline can be family aware.
 + Add option to output single-sample GVCFs
 + Make Joint Genotyping by GenotypeGVCF an optional step, so the pipeline can 
   be used for RNA variant calling.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,6 @@ Some additional inputs which may be of interest are:
   "GatkVariantCalling.vcfBasename": "The basename of the to be outputed VCF files, defaults to 'multisample'",
   "GatkVariantCalling.XNonParRergions": "Bed file with the non-PAR regions of X. Required for gender-aware variant calling.",
   "GatkVariantCalling.YNonParRegions": "Bed file with the non-PAR regions of Y. Required for gender-aware variant calling.",
-  "GatkVariantCalling.pedigree": "Pedigree file that can be used for family-aware variantcalling.", 
   "GatkVariantCalling.singleSampleGvcf": "Output Gvcfs for every single sample."
 }
 ```

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -40,6 +40,11 @@ GatkVariantCalling.
     <i>Array[File]+? </i><br />
     Bed files or interval lists describing the regions to NOT operate on.
 </dd>
+<dt id="GatkVariantCalling.callAutosomal.haplotypeCaller.pedigree"><a href="#GatkVariantCalling.callAutosomal.haplotypeCaller.pedigree">GatkVariantCalling.callAutosomal.haplotypeCaller.pedigree</a></dt>
+<dd>
+    <i>File? </i><br />
+    Pedigree file for determining the population "founders"
+</dd>
 <dt id="GatkVariantCalling.callAutosomal.haplotypeCaller.ploidy"><a href="#GatkVariantCalling.callAutosomal.haplotypeCaller.ploidy">GatkVariantCalling.callAutosomal.haplotypeCaller.ploidy</a></dt>
 <dd>
     <i>Int? </i><br />
@@ -50,10 +55,20 @@ GatkVariantCalling.
     <i>Array[File]+? </i><br />
     Bed files or interval lists describing the regions to NOT operate on.
 </dd>
+<dt id="GatkVariantCalling.callX.pedigree"><a href="#GatkVariantCalling.callX.pedigree">GatkVariantCalling.callX.pedigree</a></dt>
+<dd>
+    <i>File? </i><br />
+    Pedigree file for determining the population "founders"
+</dd>
 <dt id="GatkVariantCalling.callY.excludeIntervalList"><a href="#GatkVariantCalling.callY.excludeIntervalList">GatkVariantCalling.callY.excludeIntervalList</a></dt>
 <dd>
     <i>Array[File]+? </i><br />
     Bed files or interval lists describing the regions to NOT operate on.
+</dd>
+<dt id="GatkVariantCalling.callY.pedigree"><a href="#GatkVariantCalling.callY.pedigree">GatkVariantCalling.callY.pedigree</a></dt>
+<dd>
+    <i>File? </i><br />
+    Pedigree file for determining the population "founders"
 </dd>
 <dt id="GatkVariantCalling.dbsnpVCF"><a href="#GatkVariantCalling.dbsnpVCF">GatkVariantCalling.dbsnpVCF</a></dt>
 <dd>
@@ -65,6 +80,11 @@ GatkVariantCalling.
     <i>File? </i><br />
     Index (.tbi) file for the dbsnp VCF
 </dd>
+<dt id="GatkVariantCalling.genotypeGvcfs.pedigree"><a href="#GatkVariantCalling.genotypeGvcfs.pedigree">GatkVariantCalling.genotypeGvcfs.pedigree</a></dt>
+<dd>
+    <i>File? </i><br />
+    Pedigree file for determining the population "founders"
+</dd>
 <dt id="GatkVariantCalling.jointgenotyping"><a href="#GatkVariantCalling.jointgenotyping">GatkVariantCalling.jointgenotyping</a></dt>
 <dd>
     <i>Boolean </i><i>&mdash; Default:</i> <code>true</code><br />
@@ -74,11 +94,6 @@ GatkVariantCalling.
 <dd>
     <i>String </i><i>&mdash; Default:</i> <code>"."</code><br />
     The directory where the output files should be located
-</dd>
-<dt id="GatkVariantCalling.pedigree"><a href="#GatkVariantCalling.pedigree">GatkVariantCalling.pedigree</a></dt>
-<dd>
-    <i>File? </i><br />
-    Pedigree file for determining the population "founders"
 </dd>
 <dt id="GatkVariantCalling.regions"><a href="#GatkVariantCalling.regions">GatkVariantCalling.regions</a></dt>
 <dd>

--- a/gatk-variantcalling.wdl
+++ b/gatk-variantcalling.wdl
@@ -38,7 +38,6 @@ workflow GatkVariantCalling {
         File? dbsnpVCFIndex
         File? XNonParRegions
         File? YNonParRegions
-        File? pedigree
         File? regions
         Boolean jointgenotyping = true
         Boolean singleSampleGvcf = true
@@ -138,7 +137,6 @@ workflow GatkVariantCalling {
                 referenceFastaFai = referenceFastaFai,
                 dbsnpVCF = dbsnpVCF,
                 dbsnpVCFIndex = dbsnpVCFIndex,
-                pedigree = pedigree,
                 outputDir = scatterDir,
                 gvcf = jointgenotyping,
                 dockerImages = dockerImages
@@ -161,7 +159,6 @@ workflow GatkVariantCalling {
                     inputBamsIndex = [bamGender.index],
                     dbsnpVCF = dbsnpVCF,
                     dbsnpVCFIndex = dbsnpVCFIndex,
-                    pedigree = pedigree,
                     gvcf = jointgenotyping,
                     dockerImage = dockerImages["gatk4"]
             }
@@ -180,7 +177,6 @@ workflow GatkVariantCalling {
                         inputBamsIndex = [bamGender.index],
                         dbsnpVCF = dbsnpVCF,
                         dbsnpVCFIndex = dbsnpVCFIndex,
-                        pedigree = pedigree,
                         gvcf = jointgenotyping,
                         dockerImage = dockerImages["gatk4"]
                 }
@@ -239,7 +235,6 @@ workflow GatkVariantCalling {
                     outputPath = outputDir + "/scatters/" + basename(bed) + ".genotyped.vcf.gz",
                     dbsnpVCF = dbsnpVCF,
                     dbsnpVCFIndex = dbsnpVCFIndex,
-                    pedigree = pedigree,
                     dockerImage = dockerImages["gatk4"]
             }
         }
@@ -281,7 +276,6 @@ workflow GatkVariantCalling {
         regions: {description: "A bed file describing the regions to operate on.", category: "common"}
         XNonParRegions: {description: "Bed file with the non-PAR regions of X", category: "common"}
         YNonParRegions: {description: "Bed file with the non-PAR regions of Y", category: "common"}
-        pedigree: {description: "Pedigree file for determining the population \"founders\"", category: "common"}
         dockerImages: { description: "specify which docker images should be used for running this pipeline",
                         category: "advanced" }
         jointgenotyping: {description: "Whether to perform jointgenotyping (using HaplotypeCaller to call GVCFs and merge them with GenotypeGVCFs) or not",

--- a/haplotypecaller.wdl
+++ b/haplotypecaller.wdl
@@ -33,7 +33,6 @@ workflow Caller {
         File referenceFastaFai
         File? dbsnpVCF
         File? dbsnpVCFIndex
-        File? pedigree
         Boolean gvcf
         Map[String, String] dockerImages
     }
@@ -52,7 +51,6 @@ workflow Caller {
                 inputBamsIndex = [bamIndex],
                 dbsnpVCF = dbsnpVCF,
                 dbsnpVCFIndex = dbsnpVCFIndex,
-                pedigree = pedigree,
                 gvcf = gvcf,
                 dockerImage = dockerImages["gatk4"]
         }
@@ -72,7 +70,6 @@ workflow Caller {
         referenceFastaDict: {description: "Sequence dictionary (.dict) file of the reference.", category: "required"}
         dbsnpVCF: {description: "A dbSNP VCF file used for checking known sites.", category: "common"}
         dbsnpVCFIndex: {description: "The index (.tbi) file for the dbSNP VCF.", category: "common"}
-        pedigree: {description: "Pedigree file for determining the population \"founders\"", category: "common"}
         outputDir: {description: "The directory where the output files should be located.", category: "common"}
         gvcf: {description: "Whether the haplotypecaller should be called in GVCF mode.", category: "common"}
         dockerImages: {description: "A map with docker images to use.", category: "required"}

--- a/tests/data/gender-aware/pedigree.ped
+++ b/tests/data/gender-aware/pedigree.ped
@@ -1,2 +1,0 @@
-fam001	female	0	0	2	0
-fam002	male	0	0	1	0

--- a/tests/integration/two_sample_gender_aware.json
+++ b/tests/integration/two_sample_gender_aware.json
@@ -15,6 +15,5 @@
   "GatkVariantCalling.scatterSize": 10000,
   "GatkVariantCalling.XNonParRegions": "tests/data/gender-aware/x_non_par.bed",
   "GatkVariantCalling.YNonParRegions": "tests/data/gender-aware/y_non_par.bed",
-  "GatkVariantCalling.pedigree": "tests/data/gender-aware/pedigree.ped",
   "GatkVariantCalling.singleSampleGvcf": true
 }


### PR DESCRIPTION
This turns out not to be very useful.

Trio aware variant calling is done using a separate GATK tool that is not included yet. It may be at a later date, but for now this is out of scope.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
- [x] Documentation was updated (if required).
